### PR TITLE
PFE local dev proxy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -164,6 +164,27 @@ services:
     profiles:
       - portal
 
+  cdp-portal-frontend-proxy:
+    image: nginxproxy/nginx-proxy:1.4
+    container_name: cdp-portal-frontend-proxy
+    networks:
+      - cdpnet
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+      - "cdp.127.0.0.1.sslip.io:host-gateway"
+      - "cdp.--1.sslip.io:host-gateway"
+    environment:
+      - VIRTUAL_HOST=~^cdp\..*\.sslip\.io
+      - VIRTUAL_PATH=/
+      - VIRTUAL_PORT=3000
+      - PORT=3000
+      - NODE_ENV=development # This is required to ensure the login cookie is set as insecure, as we test over http
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./config/cdp-portal-frontend-proxy.conf:/etc/nginx/conf.d/cdp-portal-frontend-proxy.conf:ro
+    profiles:
+      - proxies
+      
 ################################################################################
   cdp-user-service-backend:
     image: defradigital/cdp-user-service-backend:${CDP_USER_SERVICE_BACKEND:-latest}
@@ -188,7 +209,6 @@ services:
       test: ["CMD", "echo", "Y29uc3QgZT1yZXF1aXJlKCJodHRwIiksdD17aG9zdG5hbWU6ImxvY2FsaG9zdCIscG9ydDpwcm9jZXNzLmVudi5QT1JULHBhdGg6Ii9oZWFsdGgiLG1ldGhvZDoiR0VUIn0sbz1lLnJlcXVlc3QodCwoZT0+e2xldCB0PSIiO2Uub24oImRhdGEiLChlPT57dCs9ZX0pKSxlLm9uKCJlbmQiLCgoKT0+e3Byb2Nlc3MuZXhpdCgwKX0pKX0pKTtvLm9uKCJlcnJvciIsKGU9Pntwcm9jZXNzLmV4aXQoMSl9KSksby5lbmQoKTsK", "|", "base64", "-d", "|", "node", "-"]
       interval: 3s
       start_period: 2s
-
     profiles:
       - portal
 

--- a/config/cdp-portal-frontend-proxy.conf
+++ b/config/cdp-portal-frontend-proxy.conf
@@ -1,0 +1,8 @@
+server {
+    listen       3000;
+
+    location / {
+        proxy_pass   http://host.docker.internal:3000;
+    }
+
+}


### PR DESCRIPTION
Redirects Portal-frontend request to localhost from cdp-proxy inside the compose network. 

Facilitates running PFE locally without changing to localhost so OIDC auth works smoothly.

PFE in local-environment must be stopped.

Uses a different profile so not accidentally started as PFE runs on the same port.

This proxy type is mostly helpful with PFE as it gets hostname based requests via the cdp-proxy.
Other backend services can mostly be exposed by port so proxying is unnecessary.

## Start PFE-proxy

First start the whole portal. 
```bash
docker compose --profile portal up -d
```
And then stop PFE only.
```bash
docker compose --profile portal stop cdp-portal-frontend
```
Start the proxy, note the different profile.
```bash
docker compose --profile proxies up -d cdp-portal-frontend-proxy
```
If you have PFE running locally `npm run dev` then the proxying will now work.
```bash
open http://cdp.127.0.0.1.sslip.io:3333/
```

## Stop PFE-proxy

```bash
docker compose --profile proxies stop cdp-portal-frontend-proxy
docker compose --profile portal up -d cdp-portal-frontend
```
