### PR TITLE
DB scaffold inside mongo

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,10 +25,6 @@ services:
       - cdpnet
     ports:
       - 27017:27017
-    # environment:
-    # - MONGO_INITDB_DATABASE=cdp-portal-backend
-    # - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
-    # - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
     volumes:
       - cdp-infra-mongodb-data:/data
       - ./scripts/mongodb:/docker-entrypoint-initdb.d
@@ -114,22 +110,22 @@ services:
     restart: "no"
 
   ################################################################################
-  setup-cdp-portal-backend:
-    image: defradigital/cdp-local-setup:latest
-    networks:
-      - cdpnet
-    env_file:
-      - ./config/local-defaults.env
-    depends_on:
-      localstack:
-        condition: service_healthy
-      cdp-portal-backend:
-        condition: service_started
-    volumes:
-      - ./scripts/portal-backend:/scripts:ro
-    restart: "no"
-    profiles:
-      - portal
+  # setup-cdp-portal-backend:
+  #   image: defradigital/cdp-local-setup:latest
+  #   networks:
+  #     - cdpnet
+  #   env_file:
+  #     - ./config/local-defaults.env
+  #   depends_on:
+  #     localstack:
+  #       condition: service_healthy
+  #     cdp-portal-backend:
+  #       condition: service_started
+  #   volumes:
+  #     - ./scripts/portal-backend:/scripts:ro
+  #   restart: "no"
+  #   profiles:
+  #     - portal
 
   ################################################################################
   cdp-portal-frontend:

--- a/compose.yml
+++ b/compose.yml
@@ -90,44 +90,6 @@ services:
       - ./config/squid.conf:/etc/squid/squid.conf:ro
 
 ################################################################################
-# Portal Init script
-################################################################################
-  setup-cdp-portal:
-    image: defradigital/cdp-local-setup:latest
-    networks:
-      - cdpnet
-    env_file:
-      - ./config/local-defaults.env
-    depends_on:
-      localstack:
-        condition: service_healthy
-      mongodb:
-        condition: service_started
-      redis:
-        condition: service_started
-    volumes:
-      - ./scripts/portal:/scripts:ro
-    restart: "no"
-
-  ################################################################################
-  # setup-cdp-portal-backend:
-  #   image: defradigital/cdp-local-setup:latest
-  #   networks:
-  #     - cdpnet
-  #   env_file:
-  #     - ./config/local-defaults.env
-  #   depends_on:
-  #     localstack:
-  #       condition: service_healthy
-  #     cdp-portal-backend:
-  #       condition: service_started
-  #   volumes:
-  #     - ./scripts/portal-backend:/scripts:ro
-  #   restart: "no"
-  #   profiles:
-  #     - portal
-
-  ################################################################################
   cdp-portal-frontend:
     image: defradigital/cdp-portal-frontend:${CDP_PORTAL_FRONTEND:-latest}
     container_name: cdp-portal-frontend
@@ -151,9 +113,9 @@ services:
     depends_on:
       cdp-portal-backend:
         condition: service_started
-      setup-cdp-portal-backend:
-        condition: service_completed_successfully
       cdp-user-service-backend:
+        condition: service_healthy
+      cdp-self-service-ops:
         condition: service_healthy
       cdp-portal-stubs:
         condition: service_healthy
@@ -231,8 +193,6 @@ services:
     environment:
       - ASPNETCORE_URLS=http://+:5094
     depends_on:
-      setup-cdp-portal:
-        condition: service_completed_successfully
       cdp-user-service-backend:
         condition: service_healthy
     profiles:
@@ -254,8 +214,6 @@ services:
       - ./config/local-defaults.env
       - ./config/cdp-self-service-ops.env
     depends_on:
-      setup-cdp-portal:
-        condition: service_completed_successfully
       cdp-portal-stubs:
         condition: service_healthy
     environment:
@@ -285,8 +243,12 @@ services:
     environment:
       - PORT=3939
     depends_on:
-      setup-cdp-portal:
-        condition: service_completed_successfully
+      localstack:
+        condition: service_healthy
+      mongodb:
+        condition: service_started
+      redis:
+        condition: service_started
     healthcheck:
       test: ["CMD", "echo", "Y29uc3QgZT1yZXF1aXJlKCJodHRwIiksdD17aG9zdG5hbWU6ImxvY2FsaG9zdCIscG9ydDpwcm9jZXNzLmVudi5QT1JULHBhdGg6Ii9oZWFsdGgiLG1ldGhvZDoiR0VUIn0sbz1lLnJlcXVlc3QodCwoZT0+e2xldCB0PSIiO2Uub24oImRhdGEiLChlPT57dCs9ZX0pKSxlLm9uKCJlbmQiLCgoKT0+e3Byb2Nlc3MuZXhpdCgwKX0pKX0pKTtvLm9uKCJlcnJvciIsKGU9Pntwcm9jZXNzLmV4aXQoMSl9KSksby5lbmQoKTsK", "|", "base64", "-d", "|", "node", "-"]
       interval: 3s

--- a/compose.yml
+++ b/compose.yml
@@ -25,8 +25,13 @@ services:
       - cdpnet
     ports:
       - 27017:27017
+    # environment:
+    # - MONGO_INITDB_DATABASE=cdp-portal-backend
+    # - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
+    # - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
     volumes:
       - cdp-infra-mongodb-data:/data
+      - ./scripts/mongodb:/docker-entrypoint-initdb.d
     restart: always
 
 ################################################################################

--- a/scripts/mongodb/10-cdp-user-service-backend-users.js
+++ b/scripts/mongodb/10-cdp-user-service-backend-users.js
@@ -1,0 +1,17 @@
+db = db.getSiblingDB("cdp-user-service-backend");
+
+db.users.insertMany([
+  {
+    _id: "90552794-0613-4023-819a-512aa9d40023",
+    name: "Test, User",
+    email: "test.user@oidc.mock",
+    github: "testuser",
+    createdAt: {
+      $date: "2023-10-26T12:51:00.028Z",
+    },
+    updatedAt: {
+      $date: "2023-10-26T12:51:00.028Z",
+    },
+    teams: ["aabe63e7-87ef-4beb-a596-c810631fc474"],
+  },
+]);

--- a/scripts/mongodb/10-cdp-user-service-backend-users.js
+++ b/scripts/mongodb/10-cdp-user-service-backend-users.js
@@ -1,17 +1,25 @@
 db = db.getSiblingDB("cdp-user-service-backend");
 
-db.users.insertMany([
+db.users.updateOne(
   {
-    _id: "90552794-0613-4023-819a-512aa9d40023",
     name: "Test, User",
     email: "test.user@oidc.mock",
     github: "testuser",
-    createdAt: {
-      $date: "2023-10-26T12:51:00.028Z",
-    },
-    updatedAt: {
-      $date: "2023-10-26T12:51:00.028Z",
-    },
-    teams: ["aabe63e7-87ef-4beb-a596-c810631fc474"],
   },
-]);
+  {
+    $setOnInsert: {
+      _id: "90552794-0613-4023-819a-512aa9d40023",
+      name: "Test, User",
+      email: "test.user@oidc.mock",
+      github: "testuser",
+      createdAt: {
+        $date: "2023-10-26T12:51:00.028Z",
+      },
+      updatedAt: {
+        $date: "2023-10-26T12:51:00.028Z",
+      },
+      teams: ["aabe63e7-87ef-4beb-a596-c810631fc474"],
+    },
+  },
+  { upsert: true }
+);

--- a/scripts/mongodb/15-cdp-user-service-backend-teams.js
+++ b/scripts/mongodb/15-cdp-user-service-backend-teams.js
@@ -1,0 +1,17 @@
+db = db.getSiblingDB("cdp-user-service-backend");
+
+db.teams.insertMany([
+  {
+    _id: "aabe63e7-87ef-4beb-a596-c810631fc474",
+    name: "Platform",
+    description: "The team that runs the platform",
+    github: "cdp-platform",
+    users: ["90552794-0613-4023-819a-512aa9d40023"],
+    createdAt: {
+      $date: "2023-10-26T12:51:00.028Z",
+    },
+    updatedAt: {
+      $date: "2023-10-26T12:51:00.028Z",
+    },
+  },
+]);

--- a/scripts/mongodb/15-cdp-user-service-backend-teams.js
+++ b/scripts/mongodb/15-cdp-user-service-backend-teams.js
@@ -1,17 +1,23 @@
 db = db.getSiblingDB("cdp-user-service-backend");
 
-db.teams.insertMany([
+db.teams.updateOne(
   {
-    _id: "aabe63e7-87ef-4beb-a596-c810631fc474",
     name: "Platform",
-    description: "The team that runs the platform",
-    github: "cdp-platform",
-    users: ["90552794-0613-4023-819a-512aa9d40023"],
-    createdAt: {
-      $date: "2023-10-26T12:51:00.028Z",
-    },
-    updatedAt: {
-      $date: "2023-10-26T12:51:00.028Z",
+  },
+  {
+    $setOnInsert: {
+      _id: "aabe63e7-87ef-4beb-a596-c810631fc474",
+      name: "Platform",
+      description: "The team that runs the platform",
+      github: "cdp-platform",
+      users: ["90552794-0613-4023-819a-512aa9d40023"],
+      createdAt: {
+        $date: "2023-10-26T12:51:00.028Z",
+      },
+      updatedAt: {
+        $date: "2023-10-26T12:51:00.028Z",
+      },
     },
   },
-]);
+  { upsert: true }
+);

--- a/scripts/mongodb/30-cdp-portal-backend-repositories.js
+++ b/scripts/mongodb/30-cdp-portal-backend-repositories.js
@@ -1,119 +1,136 @@
 db = db.getSiblingDB("cdp-portal-backend");
 
-db.repositories.insertMany([
+db.repositories.updateOne(
   {
     _id: "cdp-portal-frontend",
-    description: "cdp-portal-frontend",
-    primaryLanguage: "JavaScript",
-    url: "https://github.com/DEFRA/cdp-portal-frontend",
-    isArchived: false,
-    isTemplate: false,
-    isPrivate: false,
-    createdAt: [
-      {
-        $numberLong: "636165336850000000",
-      },
-      0,
-    ],
-    teams: [
-      {
-        github: "cdp-platform",
-        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-        name: "Platform",
-      },
-    ],
-    topics: ["cdp", "service"],
   },
+  {
+    $setOnInsert: {
+      _id: "cdp-portal-frontend",
+      description: "cdp-portal-frontend",
+      primaryLanguage: "JavaScript",
+      url: "https://github.com/DEFRA/cdp-portal-frontend",
+      isArchived: false,
+      isTemplate: false,
+      isPrivate: false,
+      createdAt: [63616533685000000, 0],
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      topics: ["cdp", "service"],
+    },
+  },
+  { upsert: true }
+);
+
+db.repositories.updateOne(
   {
     _id: "cdp-portal-backend",
-    description: "cdp-portal-backend",
-    primaryLanguage: "JavaScript",
-    url: "https://github.com/DEFRA/cdp-portal-backend",
-    isArchived: false,
-    isTemplate: false,
-    isPrivate: false,
-    createdAt: [
-      {
-        $numberLong: "636165336850000000",
-      },
-      0,
-    ],
-    teams: [
-      {
-        github: "cdp-platform",
-        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-        name: "Platform",
-      },
-    ],
-    topics: ["cdp", "service"],
   },
+  {
+    $setOnInsert: {
+      _id: "cdp-portal-backend",
+      description: "cdp-portal-backend",
+      primaryLanguage: "JavaScript",
+      url: "https://github.com/DEFRA/cdp-portal-backend",
+      isArchived: false,
+      isTemplate: false,
+      isPrivate: false,
+      createdAt: [636165336850000000, 0],
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      topics: ["cdp", "service"],
+    },
+  },
+  { upsert: true }
+);
+
+db.repositories.updateOne(
   {
     _id: "cdp-self-service-ops",
-    description: "cdp-self-service-ops",
-    primaryLanguage: "JavaScript",
-    url: "https://github.com/DEFRA/cdp-self-service-ops",
-    isArchived: false,
-    isTemplate: false,
-    isPrivate: false,
-    createdAt: [
-      {
-        $numberLong: "636165336850000000",
-      },
-      0,
-    ],
-    teams: [
-      {
-        github: "cdp-platform",
-        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-        name: "Platform",
-      },
-    ],
-    topics: ["cdp", "service"],
   },
+  {
+    $setOnInsert: {
+      _id: "cdp-self-service-ops",
+      description: "cdp-self-service-ops",
+      primaryLanguage: "JavaScript",
+      url: "https://github.com/DEFRA/cdp-self-service-ops",
+      isArchived: false,
+      isTemplate: false,
+      isPrivate: false,
+      createdAt: [636165336850000000, 0],
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      topics: ["cdp", "service"],
+    },
+  },
+  { upsert: true }
+);
+
+db.repositories.updateOne(
   {
     _id: "cdp-user-service",
-    description: "cdp-user-service",
-    primaryLanguage: "JavaScript",
-    url: "https://github.com/DEFRA/cdp-user-service",
-    isArchived: false,
-    isTemplate: false,
-    isPrivate: false,
-    createdAt: [
-      {
-        $numberLong: "636165336850000000",
-      },
-      0,
-    ],
-    teams: [
-      {
-        github: "cdp-platform",
-        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-        name: "Platform",
-      },
-    ],
-    topics: ["cdp", "service"],
   },
   {
-    _id: "cdp-env-test-suite",
-    description: "cdp-env-test-suite",
-    primaryLanguage: "JavaScript",
-    url: "https://github.com/DEFRA/cdp-env-test-suite",
-    isArchived: false,
-    isTemplate: false,
-    isPrivate: false,
-    createdAt: [
-      {
-        $numberLong: "636165336850000000",
-      },
-      0,
-    ],
-    teams: [
-      {
-        github: "cdp-platform",
-        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-        name: "Platform",
-      },
-    ],
-    topics: ["cdp", "tests"],
+    $setOnInsert: {
+      _id: "cdp-user-service",
+      description: "cdp-user-service",
+      primaryLanguage: "JavaScript",
+      url: "https://github.com/DEFRA/cdp-user-service",
+      isArchived: false,
+      isTemplate: false,
+      isPrivate: false,
+      createdAt: [636165336850000000, 0],
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      topics: ["cdp", "service"],
+    },
   },
-]);
+  { upsert: true }
+);
+
+db.repositories.updateOne(
+  {
+    _id: "cdp-env-test-suite",
+  },
+  {
+    $setOnInsert: {
+      _id: "cdp-env-test-suite",
+      description: "cdp-env-test-suite",
+      primaryLanguage: "JavaScript",
+      url: "https://github.com/DEFRA/cdp-env-test-suite",
+      isArchived: false,
+      isTemplate: false,
+      isPrivate: false,
+      createdAt: [636165336850000000, 0],
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      topics: ["cdp", "tests"],
+    },
+  },
+  { upsert: true }
+);

--- a/scripts/mongodb/30-cdp-portal-backend-repositories.js
+++ b/scripts/mongodb/30-cdp-portal-backend-repositories.js
@@ -1,0 +1,119 @@
+db = db.getSiblingDB("cdp-portal-backend");
+
+db.repositories.insertMany([
+  {
+    _id: "cdp-portal-frontend",
+    description: "cdp-portal-frontend",
+    primaryLanguage: "JavaScript",
+    url: "https://github.com/DEFRA/cdp-portal-frontend",
+    isArchived: false,
+    isTemplate: false,
+    isPrivate: false,
+    createdAt: [
+      {
+        $numberLong: "636165336850000000",
+      },
+      0,
+    ],
+    teams: [
+      {
+        github: "cdp-platform",
+        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+        name: "Platform",
+      },
+    ],
+    topics: ["cdp", "service"],
+  },
+  {
+    _id: "cdp-portal-backend",
+    description: "cdp-portal-backend",
+    primaryLanguage: "JavaScript",
+    url: "https://github.com/DEFRA/cdp-portal-backend",
+    isArchived: false,
+    isTemplate: false,
+    isPrivate: false,
+    createdAt: [
+      {
+        $numberLong: "636165336850000000",
+      },
+      0,
+    ],
+    teams: [
+      {
+        github: "cdp-platform",
+        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+        name: "Platform",
+      },
+    ],
+    topics: ["cdp", "service"],
+  },
+  {
+    _id: "cdp-self-service-ops",
+    description: "cdp-self-service-ops",
+    primaryLanguage: "JavaScript",
+    url: "https://github.com/DEFRA/cdp-self-service-ops",
+    isArchived: false,
+    isTemplate: false,
+    isPrivate: false,
+    createdAt: [
+      {
+        $numberLong: "636165336850000000",
+      },
+      0,
+    ],
+    teams: [
+      {
+        github: "cdp-platform",
+        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+        name: "Platform",
+      },
+    ],
+    topics: ["cdp", "service"],
+  },
+  {
+    _id: "cdp-user-service",
+    description: "cdp-user-service",
+    primaryLanguage: "JavaScript",
+    url: "https://github.com/DEFRA/cdp-user-service",
+    isArchived: false,
+    isTemplate: false,
+    isPrivate: false,
+    createdAt: [
+      {
+        $numberLong: "636165336850000000",
+      },
+      0,
+    ],
+    teams: [
+      {
+        github: "cdp-platform",
+        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+        name: "Platform",
+      },
+    ],
+    topics: ["cdp", "service"],
+  },
+  {
+    _id: "cdp-env-test-suite",
+    description: "cdp-env-test-suite",
+    primaryLanguage: "JavaScript",
+    url: "https://github.com/DEFRA/cdp-env-test-suite",
+    isArchived: false,
+    isTemplate: false,
+    isPrivate: false,
+    createdAt: [
+      {
+        $numberLong: "636165336850000000",
+      },
+      0,
+    ],
+    teams: [
+      {
+        github: "cdp-platform",
+        teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+        name: "Platform",
+      },
+    ],
+    topics: ["cdp", "tests"],
+  },
+]);

--- a/scripts/mongodb/40-cdp-portal-backend-artifacts.js
+++ b/scripts/mongodb/40-cdp-portal-backend-artifacts.js
@@ -1,0 +1,168 @@
+db = db.getSiblingDB("cdp-portal-backend");
+
+db.createCollection( 'artifacts');
+
+// db.artifacts.insertMany([
+//   {
+//     _id: {
+//       $oid: "6543cd26bf6d83c02b9e6850",
+//     },
+//     created: {
+//       $date: "2023-11-02T16:24:06.004Z",
+//     },
+//     repo: "cdp-self-service-ops",
+//     tag: "0.100.0",
+//     sha256:
+//       "sha256:f2b8d79f6d70fd88b6bfce2d1bd5572ced3a8f64b5cc9537223f845665c240e5",
+//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+//     serviceName: "cdp-self-service-ops",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "6553600",
+//     },
+//     runMode: "service",
+//   },
+//   {
+//     _id: {
+//       $oid: "6544f2cabf6d83c02baedd95",
+//     },
+//     created: {
+//       $date: "2023-11-03T13:16:58.099Z",
+//     },
+//     repo: "cdp-self-service-ops",
+//     tag: "0.101.0",
+//     sha256:
+//       "sha256:6330e8011f202c62de51f36f1af5a6b53868b492c3886922cbc3fa8cc4952022",
+//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+//     serviceName: "cdp-self-service-ops",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "6619136",
+//     },
+//     runMode: "service",
+//   },
+//   {
+//     _id: {
+//       $oid: "65451bf7bf6d83c02bb12c0c",
+//     },
+//     created: {
+//       $date: "2023-11-03T16:12:39.603Z",
+//     },
+//     repo: "cdp-self-service-ops",
+//     tag: "0.102.0",
+//     sha256:
+//       "sha256:917c98d3c87bdefe6b8b0b223127d59299d8fb9af51b93c072250d4b86225001",
+//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+//     serviceName: "cdp-self-service-ops",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "6684672",
+//     },
+//     runMode: "service",
+//   },
+//   {
+//     _id: {
+//       $oid: "65422bc3bf6d83c02b86dbdd",
+//     },
+//     created: {
+//       $date: "2023-11-01T10:43:15.125Z",
+//     },
+//     repo: "cdp-portal-frontend",
+//     tag: "0.170.0",
+//     sha256:
+//       "sha256:3f1827d215e5c0a3f36c1d6f9df303431f30cc81cc8f6d1507194c165410a450",
+//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+//     serviceName: "cdp-portal-frontend",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "11141120",
+//     },
+//     runMode: "service",
+//   },
+//   {
+//     _id: {
+//       $oid: "6542444dbf6d83c02b8849c9",
+//     },
+//     created: {
+//       $date: "2023-11-01T12:27:57.452Z",
+//     },
+//     repo: "cdp-portal-frontend",
+//     tag: "0.171.0",
+//     sha256:
+//       "sha256:9f59b194a343121c3ad6494cc475400419c29949e0910ada66351c3864a31e94",
+//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+//     serviceName: "cdp-portal-frontend",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "11206656",
+//     },
+//     runMode: "service",
+//   },
+//   {
+//     _id: {
+//       $oid: "65424bccbf6d83c02b88bae6",
+//     },
+//     created: {
+//       $date: "2023-11-01T12:59:56.102Z",
+//     },
+//     repo: "cdp-portal-frontend",
+//     tag: "0.172.0",
+//     sha256:
+//       "sha256:281e045fe5f07016cbe3092984c6bee5095fea778b7f6ade5c53bfc99cdc448e",
+//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+//     serviceName: "cdp-portal-frontend",
+//     scannerVersion: 1,
+//     teams: [
+//       {
+//         github: "cdp-platform",
+//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+//         name: "Platform",
+//       },
+//     ],
+//     files: [],
+//     semVer: {
+//       $numberLong: "11272192",
+//     },
+//     runMode: "service",
+//   },
+// ]);

--- a/scripts/mongodb/40-cdp-portal-backend-artifacts.js
+++ b/scripts/mongodb/40-cdp-portal-backend-artifacts.js
@@ -7,9 +7,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-02T16:24:06.004Z",
-      },
+      created: "2023-11-02T16:24:06.004Z",
       repo: "cdp-self-service-ops",
       tag: "0.100.0",
       sha256:
@@ -41,9 +39,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-03T13:16:58.099Z",
-      },
+      created: "2023-11-03T13:16:58.099Z",
       repo: "cdp-self-service-ops",
       tag: "0.101.0",
       sha256:
@@ -75,9 +71,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-03T16:12:39.603Z",
-      },
+      created: "2023-11-03T16:12:39.603Z",
       repo: "cdp-self-service-ops",
       tag: "0.102.0",
       sha256:
@@ -109,9 +103,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-01T10:43:15.125Z",
-      },
+      created: "2023-11-01T10:43:15.125Z",
       repo: "cdp-portal-frontend",
       tag: "0.170.0",
       sha256:
@@ -143,9 +135,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-01T12:27:57.452Z",
-      },
+      created: "2023-11-01T12:27:57.452Z",
       repo: "cdp-portal-frontend",
       tag: "0.171.0",
       sha256:
@@ -177,9 +167,7 @@ db.artifacts.updateOne(
   },
   {
     $setOnInsert: {
-      created: {
-        $date: "2023-11-01T12:59:56.102Z",
-      },
+      created: "2023-11-01T12:59:56.102Z",
       repo: "cdp-portal-frontend",
       tag: "0.172.0",
       sha256:

--- a/scripts/mongodb/40-cdp-portal-backend-artifacts.js
+++ b/scripts/mongodb/40-cdp-portal-backend-artifacts.js
@@ -1,168 +1,205 @@
 db = db.getSiblingDB("cdp-portal-backend");
 
-db.createCollection( 'artifacts');
+db.artifacts.updateOne(
+  {
+    repo: "cdp-self-service-ops",
+    tag: "0.100.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-02T16:24:06.004Z",
+      },
+      repo: "cdp-self-service-ops",
+      tag: "0.100.0",
+      sha256:
+        "sha256:f2b8d79f6d70fd88b6bfce2d1bd5572ced3a8f64b5cc9537223f845665c240e5",
+      githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+      serviceName: "cdp-self-service-ops",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "6553600",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);
 
-// db.artifacts.insertMany([
-//   {
-//     _id: {
-//       $oid: "6543cd26bf6d83c02b9e6850",
-//     },
-//     created: {
-//       $date: "2023-11-02T16:24:06.004Z",
-//     },
-//     repo: "cdp-self-service-ops",
-//     tag: "0.100.0",
-//     sha256:
-//       "sha256:f2b8d79f6d70fd88b6bfce2d1bd5572ced3a8f64b5cc9537223f845665c240e5",
-//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
-//     serviceName: "cdp-self-service-ops",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "6553600",
-//     },
-//     runMode: "service",
-//   },
-//   {
-//     _id: {
-//       $oid: "6544f2cabf6d83c02baedd95",
-//     },
-//     created: {
-//       $date: "2023-11-03T13:16:58.099Z",
-//     },
-//     repo: "cdp-self-service-ops",
-//     tag: "0.101.0",
-//     sha256:
-//       "sha256:6330e8011f202c62de51f36f1af5a6b53868b492c3886922cbc3fa8cc4952022",
-//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
-//     serviceName: "cdp-self-service-ops",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "6619136",
-//     },
-//     runMode: "service",
-//   },
-//   {
-//     _id: {
-//       $oid: "65451bf7bf6d83c02bb12c0c",
-//     },
-//     created: {
-//       $date: "2023-11-03T16:12:39.603Z",
-//     },
-//     repo: "cdp-self-service-ops",
-//     tag: "0.102.0",
-//     sha256:
-//       "sha256:917c98d3c87bdefe6b8b0b223127d59299d8fb9af51b93c072250d4b86225001",
-//     githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
-//     serviceName: "cdp-self-service-ops",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "6684672",
-//     },
-//     runMode: "service",
-//   },
-//   {
-//     _id: {
-//       $oid: "65422bc3bf6d83c02b86dbdd",
-//     },
-//     created: {
-//       $date: "2023-11-01T10:43:15.125Z",
-//     },
-//     repo: "cdp-portal-frontend",
-//     tag: "0.170.0",
-//     sha256:
-//       "sha256:3f1827d215e5c0a3f36c1d6f9df303431f30cc81cc8f6d1507194c165410a450",
-//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
-//     serviceName: "cdp-portal-frontend",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "11141120",
-//     },
-//     runMode: "service",
-//   },
-//   {
-//     _id: {
-//       $oid: "6542444dbf6d83c02b8849c9",
-//     },
-//     created: {
-//       $date: "2023-11-01T12:27:57.452Z",
-//     },
-//     repo: "cdp-portal-frontend",
-//     tag: "0.171.0",
-//     sha256:
-//       "sha256:9f59b194a343121c3ad6494cc475400419c29949e0910ada66351c3864a31e94",
-//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
-//     serviceName: "cdp-portal-frontend",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "11206656",
-//     },
-//     runMode: "service",
-//   },
-//   {
-//     _id: {
-//       $oid: "65424bccbf6d83c02b88bae6",
-//     },
-//     created: {
-//       $date: "2023-11-01T12:59:56.102Z",
-//     },
-//     repo: "cdp-portal-frontend",
-//     tag: "0.172.0",
-//     sha256:
-//       "sha256:281e045fe5f07016cbe3092984c6bee5095fea778b7f6ade5c53bfc99cdc448e",
-//     githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
-//     serviceName: "cdp-portal-frontend",
-//     scannerVersion: 1,
-//     teams: [
-//       {
-//         github: "cdp-platform",
-//         teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
-//         name: "Platform",
-//       },
-//     ],
-//     files: [],
-//     semVer: {
-//       $numberLong: "11272192",
-//     },
-//     runMode: "service",
-//   },
-// ]);
+db.artifacts.updateOne(
+  {
+    repo: "cdp-self-service-ops",
+    tag: "0.101.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-03T13:16:58.099Z",
+      },
+      repo: "cdp-self-service-ops",
+      tag: "0.101.0",
+      sha256:
+        "sha256:6330e8011f202c62de51f36f1af5a6b53868b492c3886922cbc3fa8cc4952022",
+      githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+      serviceName: "cdp-self-service-ops",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "6619136",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);
+
+db.artifacts.updateOne(
+  {
+    repo: "cdp-self-service-ops",
+    tag: "0.102.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-03T16:12:39.603Z",
+      },
+      repo: "cdp-self-service-ops",
+      tag: "0.102.0",
+      sha256:
+        "sha256:917c98d3c87bdefe6b8b0b223127d59299d8fb9af51b93c072250d4b86225001",
+      githubUrl: "https://github.com/DEFRA/cdp-self-service-ops",
+      serviceName: "cdp-self-service-ops",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "6684672",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);
+
+db.artifacts.updateOne(
+  {
+    repo: "cdp-portal-frontend",
+    tag: "0.170.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-01T10:43:15.125Z",
+      },
+      repo: "cdp-portal-frontend",
+      tag: "0.170.0",
+      sha256:
+        "sha256:3f1827d215e5c0a3f36c1d6f9df303431f30cc81cc8f6d1507194c165410a450",
+      githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+      serviceName: "cdp-portal-frontend",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "11141120",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);
+
+db.artifacts.updateOne(
+  {
+    repo: "cdp-portal-frontend",
+    tag: "0.171.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-01T12:27:57.452Z",
+      },
+      repo: "cdp-portal-frontend",
+      tag: "0.171.0",
+      sha256:
+        "sha256:9f59b194a343121c3ad6494cc475400419c29949e0910ada66351c3864a31e94",
+      githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+      serviceName: "cdp-portal-frontend",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "11206656",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);
+
+db.artifacts.updateOne(
+  {
+    repo: "cdp-portal-frontend",
+    tag: "0.172.0",
+  },
+  {
+    $setOnInsert: {
+      created: {
+        $date: "2023-11-01T12:59:56.102Z",
+      },
+      repo: "cdp-portal-frontend",
+      tag: "0.172.0",
+      sha256:
+        "sha256:281e045fe5f07016cbe3092984c6bee5095fea778b7f6ade5c53bfc99cdc448e",
+      githubUrl: "https://github.com/DEFRA/cdp-portal-frontend",
+      serviceName: "cdp-portal-frontend",
+      scannerVersion: 1,
+      teams: [
+        {
+          github: "cdp-platform",
+          teamId: "aabe63e7-87ef-4beb-a596-c810631fc474",
+          name: "Platform",
+        },
+      ],
+      files: [],
+      semVer: {
+        $numberLong: "11272192",
+      },
+      runMode: "service",
+    },
+  },
+  { upsert: true }
+);

--- a/scripts/mongodb/50-cdp-portal-backend-secrets.js
+++ b/scripts/mongodb/50-cdp-portal-backend-secrets.js
@@ -1,7 +1,5 @@
 db = db.getSiblingDB("cdp-portal-backend");
 
-// db.createCollection("tenantsecrets");
-
 db.tenantsecrets.updateOne(
   {
     environment: "infra-dev",

--- a/scripts/mongodb/50-cdp-portal-backend-secrets.js
+++ b/scripts/mongodb/50-cdp-portal-backend-secrets.js
@@ -2,42 +2,70 @@ db = db.getSiblingDB("cdp-portal-backend");
 
 // db.createCollection("tenantsecrets");
 
-db.tenantsecrets.insertMany([
+db.tenantsecrets.updateOne(
   {
-    _id: BSON.ObjectId("670e925aed103e51a180954b"),
+    environment: "infra-dev",
+    service: "cdp-portal-frontend",
+    keys: ["SOME_KEY"],
+  },
+  {
+    $setOnInsert: {
+      environment: "infra-dev",
+      service: "cdp-portal-frontend",
+      keys: ["SOME_KEY"],
+      lastChangedDate: "2024-10-15T16:03:38.3139986Z",
+    },
+  },
+  { upsert: true }
+);
+
+db.tenantsecrets.updateOne(
+  {
     environment: "management",
     service: "cdp-portal-frontend",
     keys: ["SOME_KEY"],
-    lastChangedDate: "2024-10-15T16:03:38.3139986Z",
   },
-]);
+  {
+    $setOnInsert: {
+      environment: "management",
+      service: "cdp-portal-frontend",
+      keys: ["SOME_KEY"],
+      lastChangedDate: "2024-10-15T16:03:38.3139986Z",
+    },
+  },
+  { upsert: true }
+);
 
-// db.tenantsecrets.insertMany([
-//   {
-//     _id: {
-//       $oid: "670e925aed103e51a180954b",
-//     },
-//     environment: "management",
-//     service: "cdp-portal-frontend",
-//     keys: ["SOME_KEY"],
-//     lastChangedDate: "2024-10-15T16:03:38.3139986Z",
-//   },
-//   {
-//     _id: {
-//       $oid: "670e925aed103e51a1809550",
-//     },
-//     environment: "infra-dev",
-//     service: "cdp-self-service-ops",
-//     keys: ["SOME_KEY"],
-//     lastChangedDate: "2024-10-15T16:03:38.8082148Z",
-//   },
-//   {
-//     _id: {
-//       $oid: "670e925bed103e51a1809555",
-//     },
-//     environment: "management",
-//     service: "cdp-self-service-ops",
-//     keys: ["SOME_KEY"],
-//     lastChangedDate: "2024-10-15T16:03:39.5206321Z",
-//   },
-// ]);
+db.tenantsecrets.updateOne(
+  {
+    environment: "infra-dev",
+    service: "cdp-self-service-ops",
+    keys: ["SOME_KEY"],
+  },
+  {
+    $setOnInsert: {
+      environment: "infra-dev",
+      service: "cdp-self-service-ops",
+      keys: ["SOME_KEY"],
+      lastChangedDate: "2024-10-15T16:03:38.8082148Z",
+    },
+  },
+  { upsert: true }
+);
+
+db.tenantsecrets.updateOne(
+  {
+    environment: "management",
+    service: "cdp-self-service-ops",
+    keys: ["SOME_KEY"],
+  },
+  {
+    $setOnInsert: {
+      environment: "management",
+      service: "cdp-self-service-ops",
+      keys: ["SOME_KEY"],
+      lastChangedDate: "2024-10-15T16:03:39.5206321Z",
+    },
+  },
+  { upsert: true }
+);

--- a/scripts/mongodb/50-cdp-portal-backend-secrets.js
+++ b/scripts/mongodb/50-cdp-portal-backend-secrets.js
@@ -1,0 +1,43 @@
+db = db.getSiblingDB("cdp-portal-backend");
+
+// db.createCollection("tenantsecrets");
+
+db.tenantsecrets.insertMany([
+  {
+    _id: BSON.ObjectId("670e925aed103e51a180954b"),
+    environment: "management",
+    service: "cdp-portal-frontend",
+    keys: ["SOME_KEY"],
+    lastChangedDate: "2024-10-15T16:03:38.3139986Z",
+  },
+]);
+
+// db.tenantsecrets.insertMany([
+//   {
+//     _id: {
+//       $oid: "670e925aed103e51a180954b",
+//     },
+//     environment: "management",
+//     service: "cdp-portal-frontend",
+//     keys: ["SOME_KEY"],
+//     lastChangedDate: "2024-10-15T16:03:38.3139986Z",
+//   },
+//   {
+//     _id: {
+//       $oid: "670e925aed103e51a1809550",
+//     },
+//     environment: "infra-dev",
+//     service: "cdp-self-service-ops",
+//     keys: ["SOME_KEY"],
+//     lastChangedDate: "2024-10-15T16:03:38.8082148Z",
+//   },
+//   {
+//     _id: {
+//       $oid: "670e925bed103e51a1809555",
+//     },
+//     environment: "management",
+//     service: "cdp-self-service-ops",
+//     keys: ["SOME_KEY"],
+//     lastChangedDate: "2024-10-15T16:03:39.5206321Z",
+//   },
+// ]);

--- a/scripts/portal/setup-mongo.sh
+++ b/scripts/portal/setup-mongo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# mongorestore --uri=mongodb://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
-# mongorestore --uri=mongodb://mongodb:27017 --gzip --db=cdp-portal-backend --archive=/scripts/cdp-portal-backend.archive --drop
+mongorestore --uri=mongodb://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
+mongorestore --uri=mongodb://mongodb:27017 --gzip --db=cdp-portal-backend --archive=/scripts/cdp-portal-backend.archive --drop

--- a/scripts/portal/setup-mongo.sh
+++ b/scripts/portal/setup-mongo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-mongorestore --uri=mongodb://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
-mongorestore --uri=mongodb://mongodb:27017 --gzip --db=cdp-portal-backend --archive=/scripts/cdp-portal-backend.archive --drop
+# mongorestore --uri=mongod/b://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
+# mongorestore --uri=mongodb://mongodb:27017 --gzip --db=cdp-portal-backend --archive=/scripts/cdp-portal-backend.archive --drop

--- a/scripts/portal/setup-mongo.sh
+++ b/scripts/portal/setup-mongo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# mongorestore --uri=mongod/b://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
+# mongorestore --uri=mongodb://mongodb:27017 --gzip --archive=/scripts/cdp-user-service-backend.archive --drop
 # mongorestore --uri=mongodb://mongodb:27017 --gzip --db=cdp-portal-backend --archive=/scripts/cdp-portal-backend.archive --drop


### PR DESCRIPTION
This removes `setup-cdp-portal` and its recent sibling `setup-cdp-portal-backend`.

This has been replaced with mongodb scaffold scrips inside the MongoDB container itself. 
So the MongoDB archives has also gone and replaced with these scripts.

The difficulties was with ObjectIds, Date objects and i64 integers. Hopefully they are now ok.

The secrets `curl` and `aws sqs` shell script is no longer needed as replaced by direct MongoDB inserts.
I have kept the shell scrips there if people need to add more secrets via CLI.
